### PR TITLE
pin requests lib to 1.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         'gunicorn>=0.14.6',
         'netaddr>=0.7.7',
         'eventlet>=0.9.17',
-        'requests>=0.14.1',
+        'requests>=0.14.1,<=1.2.0',
     ],
     namespace_packages=['akanda'],
     packages=find_packages(),


### PR DESCRIPTION
fixes bug DHC-1286

There is an unstream bug in 1.2.1+ that causes IPv6 URLs not be
reassembled correctly.  The change was recent, so pinning to a recent
older version that does not contain the bug.
