### PR TITLE
Disable DAD

### DIFF
--- a/scripts/create-akanda-livecd.sh
+++ b/scripts/create-akanda-livecd.sh
@@ -361,6 +361,11 @@ inetd=NO
 amd_master=NO
 EOF
 
+echo "[*] Add some stuff to sysctl.conf"
+cat > $WDIR/etc/sysctl.conf <<EOF
+net.inet6.ip6.dad_count=0
+EOF
+
 echo "[*] Add rc.local file...."
 cp $HERE/etc/rc.local $WDIR/etc/rc.local
 


### PR DESCRIPTION
Disable IPv6 Duplicate Address Detection for now.  For some reason,
it is breaking on the vio1 interfaces and preventing us from
assigning any IPv6 IPs to those interfaces.
