### PR TITLE
Handle single default v4 gateway

### DIFF
--- a/akanda/router/drivers/route.py
+++ b/akanda/router/drivers/route.py
@@ -30,12 +30,19 @@ class RouteManager(base.Manager):
         super(RouteManager, self).__init__(root_helper)
 
     def update_default(self, config):
+        # The default v4 gateway is pulled out as a special case
+        # because we only want one but we might have multiple v4
+        # subnets on the external network.
+        if config.default_v4_gateway:
+            self._set_default_gateway(config.default_v4_gateway)
+
+        # Set the gateway for the IPv6 network.
         for net in config.networks:
             if not net.is_external_network:
                 continue
 
             for subnet in net.subnets:
-                if subnet.gateway_ip:
+                if subnet.gateway_ip and subnet.gateway_ip.version == 6:
                     self._set_default_gateway(subnet.gateway_ip)
 
     def _get_default_gateway(self, version):

--- a/akanda/router/models.py
+++ b/akanda/router/models.py
@@ -542,6 +542,8 @@ class Network(ModelBase):
 
 class Configuration(ModelBase):
     def __init__(self, conf_dict={}):
+        gw = conf_dict.get('default_v4_gateway')
+        self.default_v4_gateway = netaddr.IPAddress(gw) if gw else None
         self.asn = conf_dict.get('asn', DEFAULT_AS)
         self.neighbor_asn = conf_dict.get('neighbor_asn', self.asn)
         self.networks = [

--- a/test/unit/test_models.py
+++ b/test/unit/test_models.py
@@ -491,6 +491,15 @@ class ConfigurationTestCase(TestCase):
         c = models.Configuration({'tenant_id': 'abc123'})
         self.assertEqual(c.tenant_id, 'abc123')
 
+    def test_no_default_v4_gateway(self):
+        c = models.Configuration({})
+        self.assertIsNone(c.default_v4_gateway)
+
+    def test_valid_default_v4_gateway(self):
+        c = models.Configuration({'default_v4_gateway': '172.16.77.1'})
+        self.assertEqual(c.default_v4_gateway.version, 4)
+        self.assertEqual(str(c.default_v4_gateway), '172.16.77.1')
+
     def test_init_only_static_routes(self):
         routes = [('0.0.0.0/0', '192.168.1.1'),
                   ('172.16.77.0/16', '192.168.1.254')]


### PR DESCRIPTION
If we are given a single v4 gateway, make sure we use it. Otherwise assume
the current gateway is OK, and do not look at the gateways of the v4 subnets
we are given.

Change-Id: Id85bda590367bf6772e2ae451e44bb0608987e26
