### PR TITLE
Handle IPv6 DHCP allocations

### DIFF
--- a/akanda/router/drivers/dnsmasq.py
+++ b/akanda/router/drivers/dnsmasq.py
@@ -80,8 +80,8 @@ class DHCPManager(base.Manager):
         config.extend(
             'dhcp-host=%s,%s,%s' % (
                 a.mac_address,
-                ','.join('[%]' % ip if ':' in ip else ip for ip in
-                         a.dhcp_addresses),
+                ','.join('[%s]' % ip if ':' in ip else ip
+                         for ip in a.dhcp_addresses),
                 a.hostname)
             for a in network.address_allocations
         )


### PR DESCRIPTION
The code for generating the dnsmasq config had a bad python string format
expression, causing an unhandled exception when any IPv6 subnet had DHCP
enabled.

Fixes DHC-2126

Change-Id: Iede9fe7179911bb6df520696a9b978a288d7a5d4
