### PR TITLE
Add pydoc information

### DIFF
--- a/akanda/router/drivers/ip.py
+++ b/akanda/router/drivers/ip.py
@@ -118,7 +118,8 @@ class IPManager(base.Manager):
 
     def up(self, interface):
         """
-        Sets the administrative mode for the network link on interface <interface> to "up".
+        Sets the administrative mode for the network link on interface
+        <interface> to "up".
         """
         real_ifname = self.generic_to_host(interface.ifname)
         self.sudo('link', 'set', real_ifname, 'up')
@@ -154,8 +155,8 @@ class IPManager(base.Manager):
         """
 
         def _gen_cmd(cmd, address):
-	    """
-	    """
+            """
+            """
             family = {4: 'inet', 6: 'inet6'}[address[0].version]
             args = [
                 'addr',


### PR DESCRIPTION
This patch adds pydoc documentaion comments to the akanda code.  The following
functions remain undocumented:

ensure_mapping
generic_to_host
host_to_generic
_update_addresses
  _get_cmd
_update_set
_alter_route
_parse_interfaces
_parse_interface
_parse_head
_parse_inet
_parse_lladdr
