### PR TITLE
Reword pydoc for pep8 compliance

### DIFF
--- a/akanda/router/drivers/bird.py
+++ b/akanda/router/drivers/bird.py
@@ -76,7 +76,7 @@ def build_config(config, interface_map):
     provided by <interface_map>.
 
     :type interface_map: dict
-    :param interface_map: A (dict) mapping of generic to physical hostname, e.g.:
+    :param interface_map: A (dict) mapping of generic to physical hostname:
                           {'ge0': 'eth0', 'ge1': 'eth1'}
     :rtype: str
     """


### PR DESCRIPTION
pydoc documentation was reworded to ensure that the line is less than
80 chars.
