### PR TITLE
revert "max ra interval" to the default of 600s

### DIFF
--- a/akanda/router/drivers/bird.py
+++ b/akanda/router/drivers/bird.py
@@ -314,7 +314,7 @@ def _build_radv_config(config, interface_map):
 
         retval.extend([
             '\tinterface "%s" {' % real_ifname,
-            '\t\tmax ra interval 10;',
+            '\t\tmax ra interval 600;',
             '\t\trdnss local yes;'
         ])
         for subnet in v6_subnets:

--- a/test/unit/drivers/test_bird.py
+++ b/test/unit/drivers/test_bird.py
@@ -225,7 +225,7 @@ class BirdTestCase(TestCase):
         expected = """
             protocol radv {
                 interface "en1" {
-                    max ra interval 10;
+                    max ra interval 600;
                     rdnss local yes;
                     prefix face::/64 {
                         autonomous off;


### PR DESCRIPTION
IIRC, Mark and I decided to be aggressive on this to be sure that RAs went out often.  It turns out that setting this so low decreases some other related timeouts and makes us more susceptible to large-scale failure during brief network outages.
