### PR TITLE
install a newer kernel from backports

### DIFF
--- a/scripts/create-akanda-raw-image.sh
+++ b/scripts/create-akanda-raw-image.sh
@@ -63,8 +63,8 @@ EOF
 echo "[*] APT Update"
 apt-get update || exit 1
 
-echo "[*] Upgrade to the 3.14 backport kernel"
-apt-get -y install linux-image-3.14-0.bpo.2-amd64
+echo "[*] Upgrade to the 3.14 backport kernel and update bash to fix CVE-2014-6271"
+apt-get -y install linux-image-3.14-0.bpo.2-amd64 bash
 
 echo "[*] Creating motd file..."
 cat >/etc/motd <<EOF


### PR DESCRIPTION
Debian's default 3.2 kernel seems to include a few IPv6-related
bugs that, in some cases, make IPv6 forwarding performance
unacceptable.  The linux-image-3.14-0.bpo.2-amd64 package
from backports appears to fix all of those known issues.
