### PR TITLE
Adding various useful debuging tools / conntrack pacakge

### DIFF
--- a/scripts/create-akanda-raw-image.sh
+++ b/scripts/create-akanda-raw-image.sh
@@ -4,7 +4,7 @@ export DEBIAN_FRONTEND=noninteractive
 APT_GET="apt-get -y"
 APPLIANCE_BASE_DIR="/tmp/akanda-appliance"
 APPLIANCE_SCRIPT_DIR="$APPLIANCE_BASE_DIR/scripts"
-PACKAGES="ntp python2.7 python-pip wget dnsmasq bird6 iptables iptables-persistent"
+PACKAGES="ntp python2.7 python-pip wget dnsmasq bird6 iptables iptables-persistent tcpdump conntrack tshark mtr"
 PACKAGES_BUILD="python-dev build-essential isc-dhcp-client"
 
 DNS=8.8.8.8


### PR DESCRIPTION
These tools (tcpdump,tshark, mtr) are useful for debugging various network issues with
routers. The conntrack pacakge will be required in future versions of the
appliance to clear old floater entries.
