### PR TITLE
Disable accept_dad on all interfaces except external

### DIFF
--- a/scripts/create-akanda-raw-image.sh
+++ b/scripts/create-akanda-raw-image.sh
@@ -140,7 +140,9 @@ cat > /etc/sysctl.conf <<EOF
 net.ipv4.ip_forward=1
 net.ipv6.conf.all.forwarding=1
 net.ipv6.conf.default.accept_dad=0
+net.ipv6.conf.eth0.accept_dad=0
 net.ipv6.conf.eth1.accept_dad=1
+net.ipv6.conf.eth2.accept_dad=0
 net.ipv4.conf.all.arp_announce=2
 EOF
 


### PR DESCRIPTION
Disable duplicate address detection on all interfaces except
the external interface (eth1). This change is to fix race conditions
with bird6 binding to tenant networks as well as SSHD binding to
the mgmt interface on boot.
