### PR TITLE
Adjust the v4 NAT to masquerade on every interface other than mgt.

### DIFF
--- a/test/unit/drivers/test_iptables.py
+++ b/test/unit/drivers/test_iptables.py
@@ -85,7 +85,7 @@ V4_OUTPUT = [
     '-A PREROUTING -i eth1 -d 172.16.77.50 -j DNAT --to-destination 192.168.0.2',  # noqa
     '-A PREROUTING -i eth2 -d 172.16.77.50 -j DNAT --to-destination 192.168.0.2',  # noqa
     '-A PREROUTING -i eth2 -d 169.254.169.254 -p tcp -m tcp --dport 80 -j DNAT --to-destination 192.168.0.1:9602',  # noqa
-    '-A POSTROUTING -o eth1 -j MASQUERADE',
+    '-A POSTROUTING ! -o eth0 -j MASQUERADE',
     'COMMIT',
     '*raw',
     ':INPUT - [0:0]',


### PR DESCRIPTION
Without this, a VM without a floating IP wouldn't be able to e.g., reach
another VM's floating IP via TCP.
