### PR TITLE
Don't masquerade traffic inbound from the internet

### DIFF
--- a/akanda/router/drivers/iptables.py
+++ b/akanda/router/drivers/iptables.py
@@ -371,6 +371,11 @@ class IPTablesManager(base.Manager):
             Rule(':FORWARD - [0:0]', ip_version=4),
             Rule(':PREROUTING - [0:0]', ip_version=4)
         ]
+        ext_if = self.get_external_network(config).interface
+        rules.append(Rule(
+            '-A PREROUTING -i %s -j MARK --set-mark 0xACDA' % ext_if.ifname,
+            ip_version=4
+        ))
 
         for network in self.networks_by_type(config, Network.TYPE_INTERNAL):
             if network.interface.first_v4:

--- a/test/unit/drivers/test_iptables.py
+++ b/test/unit/drivers/test_iptables.py
@@ -93,6 +93,7 @@ V4_OUTPUT = [
     ':OUTPUT - [0:0]',
     ':FORWARD - [0:0]',
     ':PREROUTING - [0:0]',
+    '-A PREROUTING -i eth1 -j MARK --set-mark 0xACDA',
     '-A PREROUTING -d 192.168.0.1/24 -j MARK --set-mark 0xACDA',
     ':POSTROUTING - [0:0]',
     'COMMIT'


### PR DESCRIPTION
Our MASQUERADE rule was too general.  Limit it to internally-sourced
traffic.
