### PR TITLE
Disable ipv6 dad on every non-external interface.

### DIFF
--- a/akanda/router/manager.py
+++ b/akanda/router/manager.py
@@ -62,6 +62,8 @@ class Manager(object):
         mgr.update(self.config)
 
     def update_interfaces(self):
+        for network in self.config.networks:
+            self.ip_mgr.disable_duplicate_address_detection(network)
         self.ip_mgr.update_interfaces(self.config.interfaces)
 
     def update_dhcp(self):


### PR DESCRIPTION
Duplicate address detection is not necessary on management and internal
interfaces, and it sometimes results in race conditions for services that
attempt to bind to addresses before they're "ready" (like bird6).
